### PR TITLE
Rickheil/profile doc update

### DIFF
--- a/docs/resources/customprofile.md
+++ b/docs/resources/customprofile.md
@@ -13,7 +13,7 @@ Managing custom profiles in SimpleMDM.
 ## Example Usage
 
 ```terraform
-resource "simplemdm_profile" "myprofile" {
+resource "simplemdm_customprofile" "myprofile" {
   //Custom Profile name (required)
   name = "My First profiles"
   //path to the file (required)

--- a/examples/resources/simplemdm_customprofile/resource.tf
+++ b/examples/resources/simplemdm_customprofile/resource.tf
@@ -1,4 +1,4 @@
-resource "simplemdm_profile" "myprofile" {
+resource "simplemdm_customprofile" "myprofile" {
   //Custom Profile name (required)
   name = "My First profiles"
   //path to the file (required)


### PR DESCRIPTION
The documentation and example for the custom profile resource shows the resource name as "simplemdm_profile" rather than the correct "simplemdm_customprofile".