### PR TITLE
Device Enrolment URL Fix

### DIFF
--- a/provider/device_resource.go
+++ b/provider/device_resource.go
@@ -238,6 +238,11 @@ func (r *deviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 	state.Name = types.StringValue(device.Data.Attributes.Name)
 	state.DeviceName = types.StringValue(device.Data.Attributes.Name)
 	state.DeviceGroup = types.StringValue(strconv.Itoa(device.Data.Relationships.DeviceGroup.Data.ID))
+	if device.Data.Attributes.EnrollmentURL == "" {
+		state.EnrollmentURL = types.StringValue("nil")
+	} else {
+		state.EnrollmentURL = types.StringValue(device.Data.Attributes.EnrollmentURL)
+	}
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/provider/device_resource_test.go
+++ b/provider/device_resource_test.go
@@ -40,9 +40,9 @@ func TestAccDeviceResource(t *testing.T) {
 				ResourceName:      "simplemdm_device.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The profiles, enrollmenturl and  customprofiles attributes does not exist in SimpleMDM
+				// The profiles and  customprofiles attributes does not exist in SimpleMDM
 				// API, therefore there is no value for it during import.
-				ImportStateVerifyIgnore: []string{"profiles", "customprofiles", "enrollmenturl"},
+				ImportStateVerifyIgnore: []string{"profiles", "customprofiles"},
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
Fixes:
If device was enrolled via ADE enrolment URL is not present and was causing issues on next apply.
