### PR TITLE
Fix the 404 error when the script resource is not found

### DIFF
--- a/provider/script_resource.go
+++ b/provider/script_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/DavidKrau/simplemdm-go-client"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -160,6 +161,10 @@ func (r *scriptResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Get script values from SimpleMDM
 	script, err := r.client.ScriptGet(state.ID.ValueString())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SimpleMDM Script",
 			"Could not read SimpleMDM Script "+state.ID.ValueString()+": "+err.Error(),


### PR DESCRIPTION
### Problem
When a script resource managed by Terraform is deleted without using Terraform (manually from SimpleMDM UI for example), the provider triggers an error instead of detecting that the resource does not exist anymore and planning to recreate it

### Suggested solution
If the script resource is not found, remove it from the tfstate This way it will be recreated