### PR TITLE
Removing resources if deleten via web ui

### DIFF
--- a/provider/assignmentGroup_resource.go
+++ b/provider/assignmentGroup_resource.go
@@ -308,6 +308,10 @@ func (r *assignment_groupResource) Read(ctx context.Context, req resource.ReadRe
 	// Get refreshed assignment group values from SimpleMDM
 	assignmentGroup, err := r.client.AssignmentGroupGet(state.ID.ValueString())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SimpleMDM assignment group",
 			"Could not read assignment group ID "+state.ID.ValueString()+": "+err.Error(),

--- a/provider/attribute_resourse.go
+++ b/provider/attribute_resourse.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DavidKrau/simplemdm-go-client"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -133,6 +134,10 @@ func (r *attributeResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// Get refreshed attribute value from SimpleMDM
 	attribute, err := r.client.AttributeGet(state.Name.ValueString())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SimpleMDM Attribute",
 			"Could not read SimpleMDM Attribute ID "+state.Name.ValueString()+": "+err.Error(),

--- a/provider/customProfile_resourse.go
+++ b/provider/customProfile_resourse.go
@@ -182,10 +182,7 @@ func (r *customProfileResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	if !profilefound {
-		resp.Diagnostics.AddError(
-			"Error Reading SimpleMDM custom profile",
-			"Could not read custom profles ID from array "+state.ID.ValueString(),
-		)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/provider/device_resource.go
+++ b/provider/device_resource.go
@@ -210,6 +210,10 @@ func (r *deviceResource) Read(ctx context.Context, req resource.ReadRequest, res
 	// Get device group value from SimpleMDM
 	device, err := r.client.DeviceGet(state.ID.ValueString())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SimpleMDM device",
 			"Could not read SimpleMDM device "+state.ID.ValueString()+": "+err.Error(),


### PR DESCRIPTION
Expanding solution from https://github.com/DavidKrau/terraform-provider-simplemdm/pull/8

Currently customProfile, assignmentGroup, attribute and device resources will be re-created if deleted via SimpleMDM UI. Scripts fixed in previous pull.

deviceGroup currently can not be fixed because of API limitations.  