### PR TITLE
Adding script_job resource

### DIFF
--- a/docs/resources/scriptjob.md
+++ b/docs/resources/scriptjob.md
@@ -1,0 +1,45 @@
+# simplemdm_scriptjob (Resource)
+
+The `simplemdm_scriptjob` resource allows you to manage script jobs in SimpleMDM. It is used to assign scripts to devices, groups, or assignment groups.
+
+## Example Usage
+
+```terraform
+resource "simplemdm_scriptjob" "example" {
+  script_id             = "12345"
+  device_ids            = ["device1", "device2"]
+  group_ids             = ["group1", "group2"]
+  assignment_group_ids  = ["assignment_group1"]
+  custom_attribute      = "custom_attribute_example"
+  custom_attribute_regex = "\\n"
+}
+```
+
+## Schema
+
+### Required
+
+- `script_id` (String) Required. The ID of the script to be run on the devices.
+- `device_ids` (Set of String) Required. A list of device IDs to run the script on. At least one of `device_ids`, `group_ids`, or `assignment_group_ids` must be provided.
+- `group_ids` (Set of String) Required. A list of group IDs to run the script on. At least one of `device_ids`, `group_ids`, or `assignment_group_ids` must be provided.
+- `assignment_group_ids` (Set of String) Required. A list of assignment group IDs to run the script on. At least one of `device_ids`, `group_ids`, or `assignment_group_ids` must be provided.
+
+
+The following must be declared, they can be empty but at least one must contain something to work: `device_ids`, `group_ids` and `assignment_group_ids`
+
+### Optional
+
+- `custom_attribute` (String) Optional. If provided, the output from the script will be stored in this custom attribute on each device.
+- `custom_attribute_regex` (String) Optional. A regex pattern used to sanitize the output from the script before storing it in the custom attribute.
+
+### Read-Only
+
+- `id` (String) Read-Only. The ID of the script job in SimpleMDM. Automatically generated upon creation.
+
+## Import
+
+This resource supports importing using the script job ID. For example:
+
+```shell
+terraform import simplemdm_scriptjob.example <script_job_id>
+```

--- a/examples/resources/simplemdm_scriptjob/resource.tf
+++ b/examples/resources/simplemdm_scriptjob/resource.tf
@@ -1,0 +1,8 @@
+resource "simplemdm_scriptjob" "test" {
+  script_id = "35"
+  device_ids = ["1", "2", "3"]
+  group_ids = ["4", "5"]
+  assignment_group_ids = ["6", "7"]
+  custom_attribute = "greeting_attribute"
+  custom_attribute_regex = "\\n"
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -158,6 +158,6 @@ func (p *simplemdmProvider) DataSources(_ context.Context) []func() datasource.D
 // Resources defines the resources implemented in the provider.
 func (p *simplemdmProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		CustomProfileResource, AttributeResource, AssignmentGroupResource, DeviceGroupResource, DeviceResource, ScriptResource,
+		CustomProfileResource, AttributeResource, AssignmentGroupResource, DeviceGroupResource, DeviceResource, ScriptResource, ScriptJobResource,
 	}
 }

--- a/provider/scriptJob_resource.go
+++ b/provider/scriptJob_resource.go
@@ -1,0 +1,249 @@
+package provider
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/DavidKrau/simplemdm-go-client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &attributeResource{}
+	_ resource.ResourceWithConfigure   = &attributeResource{}
+	_ resource.ResourceWithImportState = &attributeResource{}
+)
+
+// scriptJobsResourceModel maps the resource schema data.
+type scriptJobResourceModel struct {
+	ScriptId             types.String `tfsdk:"script_id"`
+	DeviceIds            types.Set    `tfsdk:"device_ids"`
+	GroupIds             types.Set    `tfsdk:"group_ids"`
+	AssignmentGroupIds   types.Set    `tfsdk:"assignment_group_ids"`
+	CustomAttribute      types.String `tfsdk:"custom_attribute"`
+	CustomAttributeRegex types.String `tfsdk:"custom_attribute_regex"`
+	ID                   types.String `tfsdk:"id"`
+}
+
+// scriptJobResource is a helper function to simplify the provider implementation.
+func ScriptJobResource() resource.Resource {
+	return &scriptJobResource{}
+}
+
+// scriptJobResource is the resource implementation.
+type scriptJobResource struct {
+	client *simplemdm.Client
+}
+
+// Configure adds the provider configured client to the resource.
+func (r *scriptJobResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*simplemdm.Client)
+}
+
+// Metadata returns the resource type name.
+func (r *scriptJobResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scriptjob"
+}
+
+// Schema defines the schema for the resource.
+func (r *scriptJobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Script resource can be used to manage Scripts Jobs.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "ID of a Script Job in SimpleMDM",
+			},
+			"script_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Required. The ID of the script to be run on the devices",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"device_ids": schema.SetAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "A comma separated list of device IDs to run the script on",
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			"group_ids": schema.SetAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "A comma separated list of group IDs to run the script on. All macOS devices from these groups will be included.",
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			"assignment_group_ids": schema.SetAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "A comma separated list of assignment group IDs to run the script on. All macOS devices from these assignment groups will be included.",
+			},
+			"custom_attribute": schema.StringAttribute{
+				Optional:    true,
+				Description: "Optional. If provided the output from the script will be stored in this custom attribute on each device.",
+			},
+			"custom_attribute_regex": schema.StringAttribute{
+				Optional:    true,
+				Description: "Optional. Used to sanitize the output from the script before storing it in the custom attribute. Can be left empty but \n is recommended.",
+			},
+		},
+	}
+}
+
+func (r *scriptJobResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Create a new resource
+func (r *scriptJobResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan scriptJobResourceModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deviceIDs, err := convertSetToSlice(plan.DeviceIds)
+	if err != nil {
+		resp.Diagnostics.AddError("Device IDs Conversion Error", "Failed to convert device IDs: "+err.Error())
+		return
+	}
+
+	groupIDs, err := convertSetToSlice(plan.GroupIds)
+	if err != nil {
+		resp.Diagnostics.AddError("Group IDs Conversion Error", "Failed to convert group IDs: "+err.Error())
+		return
+	}
+
+	assignmentGroupIDs, err := convertSetToSlice(plan.AssignmentGroupIds)
+	if err != nil {
+		resp.Diagnostics.AddError("Assignment Group IDs Conversion Error", "Failed to convert assignment group IDs: "+err.Error())
+		return
+	}
+
+	var customAttribute string
+	if !plan.CustomAttribute.IsNull() {
+		customAttribute = plan.CustomAttribute.String()
+	}
+
+	customAttributeRegex := ""
+	if !plan.CustomAttributeRegex.IsNull() {
+		customAttributeRegex = plan.CustomAttributeRegex.ValueString()
+	}
+
+	// Generate API request body from plan
+	scriptJob, err := r.client.ScriptJobCreate(
+		plan.ScriptId.ValueString(),
+		deviceIDs,
+		groupIDs,
+		assignmentGroupIDs,
+		customAttribute,
+		customAttributeRegex,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating script job",
+			"Could not create script job, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(strconv.Itoa(scriptJob.Data.ID))
+
+	// Preserve input fields in state (since they are not returned by the API)
+	plan.DeviceIds = types.SetValueMust(types.StringType, stringSliceToAttrValues(deviceIDs))
+	plan.GroupIds = types.SetValueMust(types.StringType, stringSliceToAttrValues(groupIDs))
+	plan.AssignmentGroupIds = types.SetValueMust(types.StringType, stringSliceToAttrValues(assignmentGroupIDs))
+
+	// Set state to fully populated data
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *scriptJobResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Delete doesn't have sense here, beause a job could be canceled but not deleted.
+	// For now, the schedule of a job is not perimted by the API so do nothing here.
+	return
+}
+
+func (r *scriptJobResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Get current state
+	var state scriptJobResourceModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Call API to get the script job
+	scriptJob, err := r.client.ScriptJobGet(state.ID.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SimpleMDM Script Job",
+			"Could not read SimpleMDM Script Job "+state.ID.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	// Update fields returned by the API
+	state.ScriptId = types.StringValue(scriptJob.Data.Attributes.ScriptName)
+	state.CustomAttribute = types.StringValue(scriptJob.Data.Relationships.CustomAttribute.Data.ID)
+	state.CustomAttributeRegex = types.StringValue(scriptJob.Data.Attributes.CustomAttributeRegex)
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *scriptJobResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Force the recreation by seeing an appropriate error
+	resp.Diagnostics.AddError(
+		"Update Not Supported",
+		"Updating this resource is not supported. Please destroy and recreate the resource.",
+	)
+}
+
+func convertSetToSlice(set types.Set) ([]string, error) {
+	if set.IsNull() || set.IsUnknown() {
+		return nil, nil
+	}
+
+	var result []string
+	set.ElementsAs(context.Background(), &result, false)
+	return result, nil
+}
+
+func stringSliceToAttrValues(slice []string) []attr.Value {
+	values := make([]attr.Value, len(slice))
+	for i, s := range slice {
+		values[i] = types.StringValue(s)
+	}
+	return values
+}

--- a/provider/scriptJob_resource_test.go
+++ b/provider/scriptJob_resource_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccScriptJobResource(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfig + `
+		resource "simplemdm_script" "test" {
+			name= "This is test script"
+			scriptfile = file("./testfiles/testscript.sh")
+			variablesupport = true
+		}
+
+		resource "simplemdm_device" "test" {
+			name= "Created test device"
+			devicename  = "Created test device"
+			devicegroup = 152757
+  			profiles = []
+  			customprofiles = []
+		}
+		
+		resource "simplemdm_scriptjob" "test_job" {
+			script_id              = simplemdm_script.test.id
+			device_ids             = []
+			group_ids              = [152757]
+			assignment_group_ids   = []
+		}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check the script job attributes
+					resource.TestCheckResourceAttrSet("simplemdm_scriptjob.test_job", "id"),
+					resource.TestCheckResourceAttrPair(
+						"simplemdm_scriptjob.test_job", "script_id",
+						"simplemdm_script.test", "id",
+					),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "simplemdm_script.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The filesha and  scriptfile attributes does not exist in SimpleMDM
+				// API, therefore there is no value for it during import.
+			},
+			// Update and Read testing
+			{
+				Config: providerConfig + `
+		resource "simplemdm_scriptjob" "test_job" {
+			script_id              = simplemdm_script.test.id
+			device_ids             = [1903896]
+			group_ids              = []
+			assignment_group_ids   = []
+			custom_attribute       = "updated_attribute"
+			custom_attribute_regex = "\\r"
+		}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check the updated script job attributes
+					resource.TestCheckResourceAttrSet("simplemdm_scriptjob.test_job", "id"),
+					resource.TestCheckResourceAttr("simplemdm_scriptjob.test_job", "custom_attribute", "updated_attribute"),
+					resource.TestCheckResourceAttr("simplemdm_scriptjob.test_job", "custom_attribute_regex", "\\r"),
+					resource.TestCheckResourceAttr("simplemdm_scriptjob.test_job", "script_id", "simplemdm_script.test.id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}


### PR DESCRIPTION
### Working
 - Creation
 - Reading

### Known Issues
 - Naming jobs during creation: It is currently not possible to assign a proper name to a job during creation because the SimpleMDM API does not support this feature. The API just give automatically the following name : "API Job"
 - Job scheduling: The API does not allow jobs to be scheduled for execution at this time.
 - Deleting a script job: Deleting a job is not applicable since the resource does not really exist in the SimpleMDM API. While the API mentions that jobs can be canceled, scheduling them is not yet implemented.

### Other
Update is note supported, the API doesn't allow us to do this.

### Next Step
I will contact SimpleMDM support to request the implementation of these features.