### PR TITLE
fix: preserve prior state for empty deployment_type/install_type in assignment group apps

### DIFF
--- a/provider/assignmentGroup_resource.go
+++ b/provider/assignmentGroup_resource.go
@@ -385,13 +385,35 @@ func (r *assignment_groupResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	//read apps and add them to state
+	// The SimpleMDM API does not return deployment_type and install_type on
+	// assignment group reads, so the provider receives empty strings. Preserve
+	// the value already in state to avoid perpetual plan diffs.
+	// See: https://github.com/DavidKrau/terraform-provider-simplemdm/issues/27
 	if len(assignmentGroup.Data.Relationships.Apps.Data) >= 1 {
+		priorApps := map[string]appModel{}
+		for _, a := range state.Apps {
+			priorApps[a.AppID.ValueString()] = a
+		}
+
 		state.Apps = []appModel{}
 		for _, app := range assignmentGroup.Data.Relationships.Apps.Data {
+			appID := strconv.Itoa(app.ID)
+			deploymentType := app.DeploymnetType
+			installType := app.InstallType
+
+			if prior, ok := priorApps[appID]; ok {
+				if deploymentType == "" {
+					deploymentType = prior.DeploymnetType.ValueString()
+				}
+				if installType == "" {
+					installType = prior.InstallType.ValueString()
+				}
+			}
+
 			state.Apps = append(state.Apps, appModel{
-				AppID:          types.StringValue(strconv.Itoa(app.ID)),
-				DeploymnetType: types.StringValue(app.DeploymnetType),
-				InstallType:    types.StringValue(app.InstallType),
+				AppID:          types.StringValue(appID),
+				DeploymnetType: types.StringValue(deploymentType),
+				InstallType:    types.StringValue(installType),
 			})
 		}
 	} else {


### PR DESCRIPTION
## Description

Fixes the perpetual plan diff for `deployment_type` and `install_type` on `simplemdm_assignmentgroup` app assignments.

The SimpleMDM API does not return these fields on assignment group GET responses, so `Read()` stores empty strings into state. On the next plan, the configured values (`"munki"`, `"managed"`) differ from the empty state, creating a diff that reappears after every apply.

This patch preserves the existing state values when the API returns empty strings. Non-empty API values pass through unchanged, so this becomes a no-op once the API returns these fields.

## Changes

- `provider/assignmentGroup_resource.go`: In `Read()`, build a lookup map of prior state apps by ID. When the API returns `""` for `deployment_type` or `install_type`, use the prior state value instead.

## Testing

- `go build ./...` passes
- Tested in production against 6 assignment groups — perpetual diffs eliminated

Fixes #27